### PR TITLE
feat: added typed route hook

### DIFF
--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useAppStateEvent';
 export * from './useBackHandler';
 export * from './useCombinedRef';
 export * from './useDebounce';
+export * from './useTypedRoute';

--- a/src/shared/hooks/useTypedRoute.ts
+++ b/src/shared/hooks/useTypedRoute.ts
@@ -1,0 +1,5 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { RootStackParamList } from 'services';
+
+export const useTypedRoute = <T extends keyof RootStackParamList>() =>
+  useRoute<RouteProp<RootStackParamList, T>>();


### PR DESCRIPTION
# Base problem 
When we need to use typed route we usually add types to stack params:

```
export type RootStackParamList = {
 fooRoute: { userId: string };
}
```

then add it as a prop

```
export type FooRouteProp = RouteProp<
  RootStackParamList,
  'fooRoute'
>;
```
and, eventually, use as generic type 

`const { params } = useRoute<FooRouteProp>();
`

# Solution

Add hook-helper for handle this boilerplate 

```
export const useTypedRoute = <T extends keyof RootStackParamList>() =>
  useRoute<RouteProp<RootStackParamList, T>>();
```

# Usage

Add types for stack


```
export type RootStackParamList = {
 fooRoute: { userId: string };
}
```

use helper

`const { params } = useTypedRoute<'fooRoute'>();
`